### PR TITLE
Feature/#003 dark mode in settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,4 +74,5 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
     implementation(libs.google.gson)
     implementation(libs.androidx.localbroadcastmanager)
+    implementation(libs.androidx.preference.ktx)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,12 +33,14 @@
 
         <activity
             android:name=".AboutActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:parentActivityName=".MainActivity"/>
 
         <activity
             android:name=".SettingsActivity"
             android:label="Settings"
-            android:exported="false" />
+            android:exported="false"
+            android:parentActivityName=".MainActivity"/>
 
         <service
             android:name=".services.TimerService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
         android:theme="@style/Theme.MultiTimer"
         tools:targetApi="31">
         <activity
-            android:name="com.pneumasoft.multitimer.MainActivity"
+            android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/Theme.MultiTimer">
             <intent-filter>
@@ -35,8 +35,13 @@
             android:name=".AboutActivity"
             android:exported="false" />
 
+        <activity
+            android:name=".SettingsActivity"
+            android:label="Settings"
+            android:exported="false" />
+
         <service
-            android:name="com.pneumasoft.multitimer.services.TimerService"
+            android:name=".services.TimerService"
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="specialUse|dataSync" />

--- a/app/src/main/java/com/pneumasoft/multitimer/MainActivity.kt
+++ b/app/src/main/java/com/pneumasoft/multitimer/MainActivity.kt
@@ -476,6 +476,11 @@ class MainActivity : AppCompatActivity() {
                 startActivity(intent)
                 true
             }
+            R.id.action_settings -> {
+                val intent = Intent(this, SettingsActivity::class.java)
+                startActivity(intent)
+                true
+            }
 
             else -> super.onOptionsItemSelected(item)
         }

--- a/app/src/main/java/com/pneumasoft/multitimer/SettingsActivity.kt
+++ b/app/src/main/java/com/pneumasoft/multitimer/SettingsActivity.kt
@@ -1,0 +1,61 @@
+// app/src/main/java/com/pneumasoft/multitimer/SettingsActivity.kt
+package com.pneumasoft.multitimer
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceFragmentCompat
+import android.content.SharedPreferences
+
+class SettingsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_settings)
+
+        supportFragmentManager
+            .beginTransaction()
+            .replace(R.id.settings_container, SettingsFragment())
+            .commit()
+    }
+
+    class SettingsFragment : PreferenceFragmentCompat(),
+        SharedPreferences.OnSharedPreferenceChangeListener {
+
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            setPreferencesFromResource(R.xml.preferences, rootKey)
+        }
+
+        override fun onResume() {
+            super.onResume()
+            preferenceManager.sharedPreferences?.registerOnSharedPreferenceChangeListener(this)
+        }
+
+        override fun onPause() {
+            preferenceManager.sharedPreferences?.unregisterOnSharedPreferenceChangeListener(this)
+            super.onPause()
+        }
+
+        override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+            if (key == "dark_mode") {
+                val value = sharedPreferences?.getString("dark_mode", "system") ?: "system"
+                applyTheme(value)
+            }
+        }
+
+        private fun applyTheme(darkModeValue: String) {
+            val mode = when (darkModeValue) {
+                "light" -> AppCompatDelegate.MODE_NIGHT_NO
+                "dark" -> AppCompatDelegate.MODE_NIGHT_YES
+                else -> {
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                        AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                    } else {
+                        AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
+                    }
+                }
+            }
+            AppCompatDelegate.setDefaultNightMode(mode)
+        }
+    }
+}

--- a/app/src/main/java/com/pneumasoft/multitimer/SettingsActivity.kt
+++ b/app/src/main/java/com/pneumasoft/multitimer/SettingsActivity.kt
@@ -6,7 +6,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
-import android.content.SharedPreferences
 
 class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,45 +16,28 @@ class SettingsActivity : AppCompatActivity() {
             .beginTransaction()
             .replace(R.id.settings_container, SettingsFragment())
             .commit()
+
+        // Enable back button
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
-    class SettingsFragment : PreferenceFragmentCompat(),
-        SharedPreferences.OnSharedPreferenceChangeListener {
-
+    class SettingsFragment : PreferenceFragmentCompat() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.preferences, rootKey)
-        }
 
-        override fun onResume() {
-            super.onResume()
-            preferenceManager.sharedPreferences?.registerOnSharedPreferenceChangeListener(this)
-        }
-
-        override fun onPause() {
-            preferenceManager.sharedPreferences?.unregisterOnSharedPreferenceChangeListener(this)
-            super.onPause()
-        }
-
-        override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
-            if (key == "dark_mode") {
-                val value = sharedPreferences?.getString("dark_mode", "system") ?: "system"
-                applyTheme(value)
-            }
-        }
-
-        private fun applyTheme(darkModeValue: String) {
-            val mode = when (darkModeValue) {
-                "light" -> AppCompatDelegate.MODE_NIGHT_NO
-                "dark" -> AppCompatDelegate.MODE_NIGHT_YES
-                else -> {
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-                        AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                    } else {
-                        AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
-                    }
+            // Set up the theme preference
+            val themePreference = findPreference<ListPreference>("theme_mode")
+            themePreference?.setOnPreferenceChangeListener { _, newValue ->
+                val themeMode = when (newValue as String) {
+                    "light" -> AppCompatDelegate.MODE_NIGHT_NO
+                    "dark" -> AppCompatDelegate.MODE_NIGHT_YES
+                    else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
                 }
+
+                // Apply the theme
+                AppCompatDelegate.setDefaultNightMode(themeMode)
+                true
             }
-            AppCompatDelegate.setDefaultNightMode(mode)
         }
     }
 }

--- a/app/src/main/java/com/pneumasoft/multitimer/TimerApplication.kt
+++ b/app/src/main/java/com/pneumasoft/multitimer/TimerApplication.kt
@@ -50,23 +50,15 @@ class TimerApplication : Application() {
     }
 
     private fun ApllySavedThemePreference(){
-        // Apply saved theme preference
+        // Apply the saved theme preference
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
-        val darkMode = prefs.getString("dark_mode", "system") ?: "system"
-
-        val mode = when (darkMode) {
+        val themeMode = when (prefs.getString("theme_mode", "system")) {
             "light" -> AppCompatDelegate.MODE_NIGHT_NO
             "dark" -> AppCompatDelegate.MODE_NIGHT_YES
-            else -> {
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-                    AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                } else {
-                    AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
-                }
-            }
+            else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
         }
-        AppCompatDelegate.setDefaultNightMode(mode)
 
+        AppCompatDelegate.setDefaultNightMode(themeMode)
     }
 
     private fun saveTimerStates(throwable: Throwable) {

--- a/app/src/main/java/com/pneumasoft/multitimer/TimerApplication.kt
+++ b/app/src/main/java/com/pneumasoft/multitimer/TimerApplication.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import android.util.Log
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.preference.PreferenceManager
 
 class TimerApplication : Application() {
     override fun onCreate() {
@@ -43,6 +45,28 @@ class TimerApplication : Application() {
             // Save active timer states for potential recovery
             saveTimerStates(throwable)
         }
+
+        ApllySavedThemePreference()
+    }
+
+    private fun ApllySavedThemePreference(){
+        // Apply saved theme preference
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        val darkMode = prefs.getString("dark_mode", "system") ?: "system"
+
+        val mode = when (darkMode) {
+            "light" -> AppCompatDelegate.MODE_NIGHT_NO
+            "dark" -> AppCompatDelegate.MODE_NIGHT_YES
+            else -> {
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                    AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                } else {
+                    AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
+                }
+            }
+        }
+        AppCompatDelegate.setDefaultNightMode(mode)
+
     }
 
     private fun saveTimerStates(throwable: Throwable) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/settings_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -2,6 +2,10 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_settings"
+        android:title="Settings"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_about"
         android:title="About"
         app:showAsAction="never" />

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.MultiTimer" parent="Theme.AppCompat.DayNight.DarkActionBar">
+        <!-- Dark theme colors -->
+        <item name="colorPrimary">@color/purple_200</item>
+        <item name="colorPrimaryDark">@color/purple_700</item>
+        <item name="colorAccent">@color/teal_200</item>
+        <!-- Additional dark theme attributes -->
+        <item name="android:windowBackground">@color/dark_background</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,12 @@
+<resources>
+    <string-array name="dark_mode_entries">
+        <item>System default</item>
+        <item>Light</item>
+        <item>Dark</item>
+    </string-array>
+    <string-array name="dark_mode_values">
+        <item>system</item>
+        <item>light</item>
+        <item>dark</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string-array name="dark_mode_entries">
+    <string-array name="theme_mode_entries">
         <item>System default</item>
         <item>Light</item>
         <item>Dark</item>
     </string-array>
-    <string-array name="dark_mode_values">
+    <string-array name="theme_mode_values">
         <item>system</item>
         <item>light</item>
         <item>dark</item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
+    <!-- Light theme colors -->
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
     <color name="teal_700">#FF018786</color>
+    <color name="teal_200">#FF03DAC5</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <!-- Dark theme colors -->
+    <item name="purple_200" type="color">#FFBB86FC</item>
+    <item name="dark_background" type="color">#FF121212</item>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,11 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory app:title="Appearance">
         <ListPreference
-            app:key="dark_mode"
+            app:key="theme_mode"
             app:title="Theme"
             app:summary="Choose light, dark, or system default theme"
-            app:entries="@array/dark_mode_entries"
-            app:entryValues="@array/dark_mode_values"
+            app:entries="@array/theme_mode_entries"
+            app:entryValues="@array/theme_mode_values"
             app:defaultValue="system" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,11 @@
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+    <PreferenceCategory app:title="Appearance">
+        <ListPreference
+            app:key="dark_mode"
+            app:title="Theme"
+            app:summary="Choose light, dark, or system default theme"
+            app:entries="@array/dark_mode_entries"
+            app:entryValues="@array/dark_mode_values"
+            app:defaultValue="system" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,10 +14,12 @@ localbroadcastmanager = "1.1.0"
 material = "1.10.0"
 activity = "1.8.0"
 constraintlayout = "2.1.4"
+preferenceKtx = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.16.0" }
 androidx-localbroadcastmanager = { module = "androidx.localbroadcastmanager:localbroadcastmanager", version.ref = "localbroadcastmanager" }
+androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "preferenceKtx" }
 google-gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version = "1.2.1" }


### PR DESCRIPTION
feat(theme): implement dark mode settings support

TL;DR: Add settings activity with theme options and improved navigation

- Create theme selector with light/dark/system options in settings screen
- Refactor theme preference handling for cleaner implementation
- Add proper parent activity relationships for back navigation
- Implement system-aware theme following in app startup
- Reorganize color resources with dark theme support
- Improve settings UI with proper system window insets